### PR TITLE
treat isolated_build as an alias for wheel_pep517

### DIFF
--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -72,10 +72,7 @@ def tox_package(session, venv):
 
 
 def wheel_build_package(config, session, venv):
-    if config.isolated_build:
-        reporter.warning("Disabling isolated_build, not supported with wheels.")
-    pep517 = venv.envconfig.wheel_pep517
-    if pep517:
+    if config.isolated_build or venv.envconfig.wheel_pep517:
         wheel_package = wheel_build_pep517(config, session, venv)
     else:
         wheel_package = wheel_build_legacy(config, session, venv)


### PR DESCRIPTION
the isolated_build flag is documented as enabling pep517 already: Activate isolated build environment. tox will use a virtual environment to build a source distribution from the source tree. For build tools and arguments use the pyproject.toml file as specified in PEP-517 and PEP-518.