### PR TITLE
Clean build folder in pep517 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,9 +76,8 @@ init:
   - ps: echo $env:TOXENV
   - ps: ls C:\Python*
 install:
-  - '%PYTHON_HOME%\python -mpip install --progress-bar=off tox -rci/requirements.txt'
+  - '%PYTHON_HOME%\python -mpip install tox -rci/requirements.txt'
   - '%PYTHON_HOME%\Scripts\virtualenv --version'
-  - '%PYTHON_HOME%\Scripts\easy_install --version'
   - '%PYTHON_HOME%\Scripts\pip --version'
   - '%PYTHON_HOME%\Scripts\tox --version'
 test_script:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@ Authors
 * Ionel Cristian Mărieș - https://blog.ionelmc.ro
 * Antonio Botelho - https://github.com/botant
 * Thomas Grainger - https://github.com/graingert
+* Michael Rans - https://github.com/mcarans

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -143,6 +143,7 @@ def wheel_build_pep517(config, session, venv):
     with session.newaction(venv.name, "packaging") as action:
         venv.update(action=action)
         ensure_empty_dir(config.distdir)
+        ensure_empty_dir(config.setupdir.join("build"))
         venv.test(
             name="wheel-make",
             commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -142,8 +142,10 @@ def wheel_build_pep517(config, session, venv):
         raise SystemExit(1)
     with session.newaction(venv.name, "packaging") as action:
         venv.update(action=action)
+        if not (session.config.option.wheel_dirty or venv.envconfig.wheel_dirty):
+            action.setactivity("wheel-make", "cleaning up build directory ...")
+            ensure_empty_dir(config.setupdir.join("build"))
         ensure_empty_dir(config.distdir)
-        ensure_empty_dir(config.setupdir.join("build"))
         venv.test(
             name="wheel-make",
             commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],

--- a/tests/test_tox_wheel.py
+++ b/tests/test_tox_wheel.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import tox_wheel.plugin
@@ -83,7 +85,11 @@ def test_enabled_pep517(testdir_pep517, options):
     result.stdout.fnmatch_lines([
         'py* wheel-make: *',
     ])
-    assert result.stdout.str().count('Building wheel for foobar (PEP 517)') == 4
+    if sys.version_info >= (3, 6):
+        build_string = 'Building wheel for foobar (pyproject.toml)'
+    else:
+        build_string = 'Building wheel for foobar (PEP 517)'
+    assert result.stdout.str().count(build_string) == 4
     assert result.ret == 0
 
 
@@ -121,7 +127,11 @@ wheel_build_env = build
     result.stdout.fnmatch_lines([
         'build wheel-make: *',
     ])
-    assert result.stdout.str().count('Building wheel for foobar (PEP 517)') == 2
+    if sys.version_info >= (3, 6):
+        build_string = 'Building wheel for foobar (pyproject.toml)'
+    else:
+        build_string = 'Building wheel for foobar (PEP 517)'
+    assert result.stdout.str().count(build_string) == 2
     assert result.ret == 0
 
 

--- a/tests/test_tox_wheel.py
+++ b/tests/test_tox_wheel.py
@@ -142,13 +142,26 @@ wheel_build_env = build
     assert result.ret == 0
 
 
-def test_enabled_toxini_noclean(testdir_legacy, options):
+def test_enabled_toxini_noclean_legacy(testdir_legacy, options):
     testdir_legacy.tmpdir.join('tox.ini').write("""
 [testenv]
 wheel = true
 wheel_dirty = true
 """, mode='a')
     result = testdir_legacy.run('tox', *options)
+    result.stdout.fnmatch_lines([
+        'py* wheel-make: *',
+    ])
+    assert 'cleaning up build directory ...' not in result.stdout.str()
+    assert 'cleaning up build directory ...' not in result.stderr.str()
+    assert result.ret == 0
+
+
+def test_enabled_toxini_noclean_pep517(testdir_pep517, options):
+    testdir_pep517.tmpdir.join('tox.ini').write("""
+wheel_dirty = true
+""", mode='a')
+    result = testdir_pep517.run('tox', *options)
     result.stdout.fnmatch_lines([
         'py* wheel-make: *',
     ])


### PR DESCRIPTION
Cleans the {project_root}/build dir for pep517 builds similarly to legacy builds. Test added for this.

Fixes https://github.com/ionelmc/tox-wheel/issues/15

Doing a fresh checkout of the repository without any of my changes and running tox, some tests for Python 3.x fail. 

I think the reason is because of what is output for PEP517 runs. For example, for Py2.7 and Py3.5, the test_enabled_pep517 test outputs 'Building wheel for foobar (PEP 517)'. However, for Py3.6+, it outputs 'Building wheel for foobar (pyproject.toml)' I have updated the tests to fix this.