### PR TITLE
Accumulate wheels

### DIFF
--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -157,7 +157,7 @@ def wheel_build_pep517(config, session, venv):
         venv.test(
             name="wheel-make",
             # commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
-            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", 'dist']],
+            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", '../dist']],
             redirect=False,
             ignore_outcome=False,
             ignore_errors=False,
@@ -165,7 +165,7 @@ def wheel_build_pep517(config, session, venv):
         )
         try:
             # dists = config.distdir.listdir()
-            dists = os.listdir('dist')
+            dists = os.listdir('../dist')
         except py.error.ENOENT:
             reporter.error(
                 "No dist directory found. Please check pyproject.toml, e.g with:\n"

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -34,7 +34,7 @@ def tox_addoption(parser):
     parser.add_testenv_attribute(
         name="wheel_pep517",
         type="bool",
-        default=False,
+        default=True,
         help="Build wheel using PEP 517/518"
     )
     parser.add_testenv_attribute(

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -153,11 +153,19 @@ def wheel_build_pep517(config, session, venv):
         if not (session.config.option.wheel_dirty or venv.envconfig.wheel_dirty):
             action.setactivity("wheel-make", "cleaning up build directory ...")
             ensure_empty_dir(config.setupdir.join("build"))
-            ensure_empty_dir(config.distdir)
+        ensure_empty_dir(config.distdir)
         venv.test(
             name="wheel-make",
             commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
             # commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", '../dist']],
+            redirect=False,
+            ignore_outcome=False,
+            ignore_errors=False,
+            display_hash_seed=False,
+        )
+        venv.test(
+            name="spare-wheel",
+            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", '~/dist']],
             redirect=False,
             ignore_outcome=False,
             ignore_errors=False,

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -156,16 +156,24 @@ def wheel_build_pep517(config, session, venv):
             ensure_empty_dir(config.distdir)
         venv.test(
             name="wheel-make",
-            # commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
-            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", '../dist']],
+            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
+            # commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", '../dist']],
+            redirect=False,
+            ignore_outcome=False,
+            ignore_errors=False,
+            display_hash_seed=False,
+        )
+        venv.test(
+            name="wheel-cp",
+            commands=[["cp", config.distdir + '/*.whl', 'dist/']],
             redirect=False,
             ignore_outcome=False,
             ignore_errors=False,
             display_hash_seed=False,
         )
         try:
-            # dists = config.distdir.listdir()
-            dists = os.listdir('../dist')
+            dists = config.distdir.listdir()
+            # dists = os.listdir('../dist')
         except py.error.ENOENT:
             reporter.error(
                 "No dist directory found. Please check pyproject.toml, e.g with:\n"

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from functools import partial
+import os
 
 import pluggy
 import py
@@ -155,14 +156,16 @@ def wheel_build_pep517(config, session, venv):
             ensure_empty_dir(config.distdir)
         venv.test(
             name="wheel-make",
-            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
+            # commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],
+            commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", 'dist']],
             redirect=False,
             ignore_outcome=False,
             ignore_errors=False,
             display_hash_seed=False,
         )
         try:
-            dists = config.distdir.listdir()
+            # dists = config.distdir.listdir()
+            dists = os.listdir('dist')
         except py.error.ENOENT:
             reporter.error(
                 "No dist directory found. Please check pyproject.toml, e.g with:\n"

--- a/src/tox_wheel/plugin.py
+++ b/src/tox_wheel/plugin.py
@@ -152,7 +152,7 @@ def wheel_build_pep517(config, session, venv):
         if not (session.config.option.wheel_dirty or venv.envconfig.wheel_dirty):
             action.setactivity("wheel-make", "cleaning up build directory ...")
             ensure_empty_dir(config.setupdir.join("build"))
-        ensure_empty_dir(config.distdir)
+            ensure_empty_dir(config.distdir)
         venv.test(
             name="wheel-make",
             commands=[["pip", "wheel", config.setupdir, "--no-deps", "--use-pep517", "--wheel-dir", config.distdir]],


### PR DESCRIPTION
~~This would close https://github.com/ionelmc/tox-wheel/issues/19, but I'm guessing there's a reason the distdir is always cleaned out even when the build dir isn't.~~

This is currently a rough draft that places wheels in an arbitrary directory.
This just serves to show that we can get the wheels this way: https://gitlab.com/library-cookiecutters/python-nameless/-/jobs/2227216026/artifacts/browse/dist/